### PR TITLE
Prevent Key interaction if not signed in

### DIFF
--- a/src/components/cache/undo.tsx
+++ b/src/components/cache/undo.tsx
@@ -3,12 +3,14 @@ import { useEffect } from 'react'
 
 export function UndoCache() {
     const setUser = useStore((state) => state.setUser)
+    const setModels = useStore((state) => state.setModels)
     const setThreads = useStore((state) => state.setThreads)
 
     useEffect(() => {
         setUser({ isSignedIn: false })
         setThreads([])
-    }, [setUser, setThreads])
+        setModels([])
+    }, [setModels, setThreads, setUser])
 
     return null
 }

--- a/src/components/cache/undo.tsx
+++ b/src/components/cache/undo.tsx
@@ -5,12 +5,14 @@ export function UndoCache() {
     const setUser = useStore((state) => state.setUser)
     const setModels = useStore((state) => state.setModels)
     const setThreads = useStore((state) => state.setThreads)
+    const setThreadSearch = useStore((state) => state.setThreadSearch)
 
     useEffect(() => {
         setUser({ isSignedIn: false })
         setModels([])
         setThreads([])
-    }, [setModels, setThreads, setUser])
+        setThreadSearch('')
+    }, [setModels, setThreads, setUser, setThreadSearch])
 
     return null
 }

--- a/src/components/cache/undo.tsx
+++ b/src/components/cache/undo.tsx
@@ -8,8 +8,8 @@ export function UndoCache() {
 
     useEffect(() => {
         setUser({ isSignedIn: false })
-        setThreads([])
         setModels([])
+        setThreads([])
     }, [setModels, setThreads, setUser])
 
     return null

--- a/src/components/input/api-keys.tsx
+++ b/src/components/input/api-keys.tsx
@@ -7,9 +7,11 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { api } from '@/convex/_generated/api'
+import { useStore } from '@/lib/zustand/store'
 
 export function InputApiKeys() {
     const [isOpen, setIsOpen] = useState(false)
+    const user = useStore((state) => state.user)
     const storedApiKeys = useQuery(api.get.apiKeys)
     const setApiKey = useMutation(api.update.apiKey)
     const removeApiKey = useMutation(api.remove.apiKey)
@@ -52,7 +54,7 @@ export function InputApiKeys() {
     return (
         <Dialog open={isOpen} onOpenChange={handleOpenChange}>
             <DialogTrigger asChild>
-                <Button variant="outline" size="icon" className="relative">
+                <Button variant="outline" size="icon" className="relative" disabled={!user?.isSignedIn}>
                     <KeyIcon />
                     {hasAllStoredKeys && <div className="absolute right-1.5 bottom-1.5 size-1 rounded-full bg-green-500" />}
                     {hasPartialStoredKeys && <div className="absolute right-1.5 bottom-1.5 size-1 rounded-full bg-orange-500" />}


### PR DESCRIPTION
# Summary
This pull request introduces updates to improve state management and enhance user experience by integrating Zustand state into components and adding conditional UI behavior. The key changes involve using the Zustand store to manage user and model states and disabling a button based on the user's sign-in status.

### State management updates:
* [`src/components/cache/undo.tsx`](diffhunk://#diff-afdfe2442d37169c22f0ed3fc0caa277447d54c84971c8fab6543dd64069c748R6-R13): Added `setModels` to the Zustand store and updated the `useEffect` dependency array to include `setModels`. This ensures the models state is reset alongside the user and threads states.
* [`src/components/input/api-keys.tsx`](diffhunk://#diff-5aa3e5a2f34fcb90a2a8dec679afe03c4c446379a5411e2f0cb962f06ece26d4R10-R14): Integrated Zustand's `user` state into the `InputApiKeys` component by importing `useStore` and accessing the `user` state.

### UI behavior enhancements:
* [`src/components/input/api-keys.tsx`](diffhunk://#diff-5aa3e5a2f34fcb90a2a8dec679afe03c4c446379a5411e2f0cb962f06ece26d4L55-R57): Disabled the API keys button if the user is not signed in (`!user?.isSignedIn`). This provides a better user experience by preventing actions for unauthenticated users.